### PR TITLE
Implement getReport and expose via CLI

### DIFF
--- a/packages/scan/src/cli.mts
+++ b/packages/scan/src/cli.mts
@@ -239,8 +239,8 @@ const init = async () => {
         }
         count = localCount;
       };
-      const reportData = globalHook.ReactScanInternals.Store.reportData;
-      if (!Object.keys(reportData).length) return;
+      const reportData = globalHook.ReactScanInternals.getReport();
+      if (!reportData || !Object.keys(reportData).length) return;
 
       // biome-ignore lint/suspicious/noConsole: Intended debug output
       console.log('REACT_SCAN_REPORT', count);

--- a/packages/scan/src/core/index.ts
+++ b/packages/scan/src/core/index.ts
@@ -228,6 +228,10 @@ export interface StoreType {
 
 export type OutlineKey = `${string}-${string}`;
 
+export type GetReport = (
+  type?: ComponentType<unknown>,
+) => Record<string, RenderData> | RenderData | null;
+
 export interface Internals {
   instrumentation: ReturnType<typeof createInstrumentation> | null;
   componentAllowList: WeakMap<ComponentType<unknown>, Options> | null;
@@ -238,6 +242,7 @@ export interface Internals {
   onRender: ((fiber: Fiber, renders: Array<Render>) => void) | null;
   Store: StoreType;
   version: string;
+  getReport: GetReport;
 }
 
 export type FunctionalComponentStateChange = {
@@ -325,6 +330,7 @@ export const ReactScanInternals: Internals = {
   activeOutlines: new Map(),
   Store,
   version: packageJson.version,
+  getReport,
 };
 
 if (IS_CLIENT && window.__REACT_SCAN_EXTENSION__) {
@@ -441,17 +447,17 @@ const validateOptions = (options: Partial<Options>): Partial<Options> => {
   return validOptions;
 };
 
-export const getReport = (type?: ComponentType<unknown>) => {
+export function getReport(type?: ComponentType<unknown>) {
   if (type) {
-    for (const reportData of Array.from(Store.legacyReportData.values())) {
+    for (const reportData of Store.reportData.values()) {
       if (reportData.type === type) {
         return reportData;
       }
     }
     return null;
   }
-  return Store.legacyReportData;
-};
+  return Object.fromEntries(Store.reportData);
+}
 
 export const setOptions = (userOptions: Partial<Options>) => {
   const validOptions = validateOptions(userOptions);


### PR DESCRIPTION
## Summary
- expose `getReport` from ReactScanInternals
- implement `getReport` using new report store
- use `getReport` in CLI when polling

## Testing
- `pnpm lint` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-9.1.0.tgz)*