### PR TITLE
Fix toSorted compatibility

### DIFF
--- a/packages/scan/src/auto.ts
+++ b/packages/scan/src/auto.ts
@@ -1,3 +1,6 @@
+// Polyfill features before running anything else
+import './polyfills';
+
 // Prioritize bippy side-effect
 import 'bippy';
 

--- a/packages/scan/src/index.ts
+++ b/packages/scan/src/index.ts
@@ -1,3 +1,6 @@
+// Polyfills must load before anything else
+import './polyfills';
+
 // Bippy has a side-effect that installs the hook.
 import 'bippy';
 

--- a/packages/scan/src/polyfills.ts
+++ b/packages/scan/src/polyfills.ts
@@ -1,0 +1,9 @@
+if (!Array.prototype.toSorted) {
+  Object.defineProperty(Array.prototype, 'toSorted', {
+    value: function <T>(this: Array<T>, compareFn?: (a: T, b: T) => number): Array<T> {
+      return [...this].sort(compareFn);
+    },
+    writable: true,
+    configurable: true,
+  });
+}


### PR DESCRIPTION
## Summary
- polyfill `Array.prototype.toSorted`
- load polyfill before library code

## Testing
- `pnpm -F scan test` *(fails: connect EHOSTUNREACH)*