### PR TITLE
Fix getPropsChanges iteration

### DIFF
--- a/packages/scan/src/core/get-props-changes.test.ts
+++ b/packages/scan/src/core/get-props-changes.test.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect } from 'vitest';
+import { getPropsChanges, ChangeReason } from '~core/instrumentation';
+
+describe('getPropsChanges', () => {
+  it('returns changes for each prop name', () => {
+    const fiber = {
+      memoizedProps: { a: 2, b: 3 },
+      alternate: { memoizedProps: { a: 1 } },
+    } as any;
+
+    const changes = getPropsChanges(fiber);
+
+    expect(changes).toEqual([
+      { type: ChangeReason.Props, name: 'a', value: 2 },
+      { type: ChangeReason.Props, name: 'b', value: 3 },
+    ]);
+  });
+});

--- a/packages/scan/src/core/instrumentation.ts
+++ b/packages/scan/src/core/instrumentation.ts
@@ -197,7 +197,7 @@ export const getPropsChanges = (fiber: Fiber) => {
     ...Object.keys(prevProps),
     ...Object.keys(nextProps),
   ]);
-  for (const propName in allKeys) {
+  for (const propName of allKeys) {
     // const prevValue = prevProps?.[propName];
     const nextValue = nextProps?.[propName];
 


### PR DESCRIPTION
## Summary
- fix prop iteration in `getPropsChanges`
- add unit test for `getPropsChanges`

## Testing
- `pnpm --filter react-scan test` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-9.1.0.tgz)*