### PR TITLE
Fix widget bounding comment

### DIFF
--- a/packages/scan/src/web/widget/helpers.ts
+++ b/packages/scan/src/web/widget/helpers.ts
@@ -102,7 +102,7 @@ export const calculatePosition = (
   // Check if widget is minimized
   const isMinimized = width === MIN_SIZE.width;
 
-  // Only bound dimensions if minimized
+  // Only bound dimensions if the widget is not minimized
   const effectiveWidth = isMinimized
     ? width
     : Math.min(width, windowWidth - SAFE_AREA * 2);


### PR DESCRIPTION
## Summary
- fix comment so we bound dimensions when the widget is **not** minimized

## Testing
- `pnpm lint` *(fails: connect EHOSTUNREACH)*