### PR TITLE
Fix peer dependency for react-router

### DIFF
--- a/packages/scan/package.json
+++ b/packages/scan/package.json
@@ -253,7 +253,7 @@
     "publint": "^0.2.12",
     "react": "*",
     "react-dom": "*",
-    "react-router": "^5.0.0",
+    "react-router": "^5.0.0 || ^6.0.0 || ^7.0.0",
     "react-router-dom": "^5.0.0 || ^6.0.0 || ^7.0.0",
     "tailwind-merge": "^2.5.5",
     "terser": "^5.36.0",


### PR DESCRIPTION
## Summary
- widen `react-router` dev dependency range to include v7

## Testing
- `npx biome lint packages/scan` *(fails: connect EHOSTUNREACH)*