### PR TITLE
Fix memoizable detection for React Compiler

### DIFF
--- a/packages/scan/src/web/views/notifications/data.ts
+++ b/packages/scan/src/web/views/notifications/data.ts
@@ -1,6 +1,8 @@
 import { createContext } from 'preact';
 import { SetStateAction } from 'preact/compat';
 import { Dispatch, useContext } from 'preact/hooks';
+import { hasMemoCache, type Fiber } from 'bippy';
+import { getFiberFromElement } from '../inspector/utils';
 import { HIGH_SEVERITY_FPS_DROP_TIME } from '~core/notifications/event-tracking';
 
 export type GroupedFiberRender = {
@@ -72,11 +74,21 @@ export type InteractionTiming = {
   frameDraw: number | null;
 };
 
-export const isRenderMemoizable = (gropedFiberRender: GroupedFiberRender) => {
+export const isRenderMemoizable = (
+  groupedFiberRender: GroupedFiberRender,
+): boolean => {
+  const hostEl = groupedFiberRender.elements[0];
+  if (hostEl) {
+    const fiber = getFiberFromElement(hostEl);
+    if (fiber && hasMemoCache(fiber as Fiber)) {
+      return false;
+    }
+  }
+
   return (
-    gropedFiberRender.changes.context.length === 0 &&
-    gropedFiberRender.changes.props.length === 0 &&
-    gropedFiberRender.changes.state.length === 0
+    groupedFiberRender.changes.context.length === 0 &&
+    groupedFiberRender.changes.props.length === 0 &&
+    groupedFiberRender.changes.state.length === 0
   );
 };
 


### PR DESCRIPTION
## Summary
- prevent "Memoizable" label for components already memoized by the React Compiler

## Testing
- `pnpm -r lint` *(fails: unable to download pnpm)*
- `pnpm --filter ./packages/scan test` *(fails: unable to download pnpm)*