### PR TITLE
Implement configurable preferred FPS

### DIFF
--- a/packages/scan/src/core/index.ts
+++ b/packages/scan/src/core/index.ts
@@ -161,6 +161,13 @@ export interface Options {
   showFPS?: boolean;
 
   /**
+   * Preferred frames per second target
+   *
+   * @default 60
+   */
+  preferredFPS?: number;
+
+  /**
    * Should the number of slowdown notifications be shown in the toolbar
    *
    *  @default true
@@ -320,6 +327,7 @@ export const ReactScanInternals: Internals = {
     animationSpeed: 'fast',
     dangerouslyForceRunInProduction: false,
     showFPS: true,
+    preferredFPS: 60,
     showNotificationCount: true,
     allowInIframe: false,
     // smoothlyAnimateOutlines: true,
@@ -373,6 +381,13 @@ const validateOptions = (options: Partial<Options>): Partial<Options> => {
           errors.push(`- ${key} must be a boolean. Got "${value}"`);
         } else {
           validOptions[key] = value;
+        }
+        break;
+      case 'preferredFPS':
+        if (typeof value !== 'number' || value <= 0) {
+          errors.push(`- ${key} must be a positive number. Got "${value}"`);
+        } else {
+          validOptions.preferredFPS = value;
         }
         break;
       // case 'renderCountThreshold':

--- a/packages/scan/src/core/instrumentation.ts
+++ b/packages/scan/src/core/instrumentation.ts
@@ -58,7 +58,7 @@ export const getFPS = () => {
   if (!initedFps) {
     initedFps = true;
     updateFPS();
-    fps = 60;
+    fps = ReactScanInternals.options.value.preferredFPS;
   }
 
   return fps;

--- a/packages/scan/src/core/notifications/event-tracking.ts
+++ b/packages/scan/src/core/notifications/event-tracking.ts
@@ -1,5 +1,6 @@
 import { useSyncExternalStore } from 'preact/compat';
 import { not_globally_unique_generateId } from '~core/monitor/utils';
+import { getOptions } from '../index';
 import { MAX_INTERACTION_BATCH, interactionStore } from './interaction-store';
 import {
   FiberRenders,
@@ -316,7 +317,11 @@ export const startDirtyTaskTracking = () => {
   };
 };
 
-export const HIGH_SEVERITY_FPS_DROP_TIME = 150;
+export const getHighSeverityFpsDropTime = () =>
+  (1000 / getOptions().value.preferredFPS) * 9;
+
+export const getLowSeverityFpsDropTime = () =>
+  (1000 / getOptions().value.preferredFPS) * 3;
 
 let framesDrawnInTheLastSecond: Array<number> = [];
 
@@ -354,7 +359,7 @@ export function startLongPipelineTracking() {
         const wasTaskInfluencedByToolbar = overToolbar !== null && overToolbar;
 
         if (
-          duration > HIGH_SEVERITY_FPS_DROP_TIME &&
+          duration > getHighSeverityFpsDropTime() &&
           !taskConsideredDirty &&
           document.visibilityState === 'visible' &&
           !wasTaskInfluencedByToolbar

--- a/packages/scan/src/web/views/inspector/overlay/index.tsx
+++ b/packages/scan/src/web/views/inspector/overlay/index.tsx
@@ -31,7 +31,8 @@ interface LockIconRect {
 }
 
 const ANIMATION_CONFIG = {
-  frameInterval: 1000 / 60,
+  getFrameInterval: () =>
+    1000 / ReactScanInternals.options.value.preferredFPS,
   speeds: {
     fast: 0.51,
     slow: 0.1,
@@ -191,7 +192,7 @@ export const ScanOverlay = () => {
     const animationFrame = (timestamp: number) => {
       if (
         timestamp - refLastFrameTime.current <
-        ANIMATION_CONFIG.frameInterval
+        ANIMATION_CONFIG.getFrameInterval()
       ) {
         refRafId.current = requestAnimationFrame(animationFrame);
         return;

--- a/packages/scan/src/web/views/notifications/data.ts
+++ b/packages/scan/src/web/views/notifications/data.ts
@@ -3,7 +3,10 @@ import { SetStateAction } from 'preact/compat';
 import { Dispatch, useContext } from 'preact/hooks';
 import { hasMemoCache, type Fiber } from 'bippy';
 import { getFiberFromElement } from '../inspector/utils';
-import { HIGH_SEVERITY_FPS_DROP_TIME } from '~core/notifications/event-tracking';
+import {
+  getHighSeverityFpsDropTime,
+  getLowSeverityFpsDropTime,
+} from '~core/notifications/event-tracking';
 
 export type GroupedFiberRender = {
   id: string;
@@ -180,8 +183,8 @@ export const getEventSeverity = (event: NotificationEvent) => {
       return 'high';
     }
     case 'dropped-frames': {
-      if (totalTime < 50) return 'low';
-      if (totalTime < HIGH_SEVERITY_FPS_DROP_TIME) return 'needs-improvement';
+      if (totalTime < getLowSeverityFpsDropTime()) return 'low';
+      if (totalTime < getHighSeverityFpsDropTime()) return 'needs-improvement';
       return 'high';
     }
   }

--- a/packages/scan/src/web/views/notifications/other-visualization.tsx
+++ b/packages/scan/src/web/views/notifications/other-visualization.tsx
@@ -1,6 +1,6 @@
 import { ReactNode } from 'preact/compat';
 import { useContext, useEffect, useState } from 'preact/hooks';
-import { getIsProduction } from '~core/index';
+import { getIsProduction, getOptions } from '~core/index';
 import { iife } from '~core/notifications/performance-utils';
 import { cn } from '~web/utils/helpers';
 import {
@@ -508,8 +508,13 @@ const Explanation = ({ input }: { input: OverviewInput }) => {
           ])}
         >
           <p>
-            This is the time it took to draw the entire frame that was presented
-            to the user. To be at 60FPS, this number needs to be {'<=16ms'}
+            {(() => {
+              const preferred = getOptions().value.preferredFPS;
+              const budget = Math.round(1000 / preferred);
+              return (
+                <>This is the time it took to draw the entire frame that was presented to the user. To be at {preferred}FPS, this number needs to be {'<=' + budget + 'ms'}</>
+              );
+            })()}
           </p>
 
           <p>

--- a/packages/scan/src/web/widget/fps-meter.tsx
+++ b/packages/scan/src/web/widget/fps-meter.tsx
@@ -1,13 +1,15 @@
 import { useEffect, useState } from 'preact/hooks';
 import { getFPS } from '~core/instrumentation';
+import { getOptions } from '~core';
 import { cn } from '~web/utils/helpers';
 
 export const FpsMeterInner = ({fps}:{fps: number}) => {
 
 
   const getColor = (fps: number) => {
-    if (fps < 30) return '#EF4444';
-    if (fps < 50) return '#F59E0B';
+    const preferred = getOptions().value.preferredFPS;
+    if (fps < preferred / 2) return '#EF4444';
+    if (fps < (preferred * 5) / 6) return '#F59E0B';
     return 'rgb(214,132,245)';
   };
 


### PR DESCRIPTION
## Summary
- add `preferredFPS` option with default 60
- use preferredFPS throughout UI for animations and messages
- adjust FPS meter colors and overlay timing

## Testing
- `pnpm lint` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-9.1.0.tgz)*