### PR TITLE
Add child windows guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ yarn add react-scan
 - [Astro](https://github.com/aidenybai/react-scan/blob/main/docs/installation/astro.md)
 - [TanStack Start](https://github.com/aidenybai/react-scan/blob/main/docs/installation/tanstack-start.md)
 - [Rsbuild](https://github.com/aidenybai/react-scan/blob/main/docs/installation/rsbuild.md)
+- [Child Windows](https://github.com/aidenybai/react-scan/blob/main/docs/guides/child-windows.md)
 
 ### CLI
 

--- a/docs/guides/child-windows.md
+++ b/docs/guides/child-windows.md
@@ -1,0 +1,19 @@
+# Using React Scan with Child Windows
+
+React Scan only monitors the window where it is loaded. When rendering components into a new `window.open()` portal, install React Scan inside that child window as well.
+
+```ts
+const win = window.open('/child', 'child');
+win.addEventListener('load', () => {
+  const script = win.document.createElement('script');
+  script.type = 'module';
+  script.src = '/path/to/react-scan.js';
+  script.onload = () => {
+    // reactScan is exposed as a global
+    (win as any).reactScan({ enabled: true });
+  };
+  win.document.head.appendChild(script);
+});
+```
+
+This injects the React Scan script and activates scanning for the new window. Each child window must mount its own instance for outlines and toolbar to appear.


### PR DESCRIPTION
## Summary
- document how to run React Scan in a `window.open()` child window
- reference the new doc from README

## Testing
- `pnpm lint:all` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-9.1.0.tgz)*